### PR TITLE
Removed circular dependency on itself

### DIFF
--- a/src/RandomGen/RandomGen.nuspec
+++ b/src/RandomGen/RandomGen.nuspec
@@ -11,8 +11,5 @@
     <description>$description$</description>
     <copyright>Copyright 2012</copyright>
     <tags>random randomise normal distribution female male name surname word</tags>
-    <dependencies>
-      <dependency id="RandomGen" version="$version$" />
-    </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Right now it's impossible to install the NuGet package as it has a dependency on itself.
